### PR TITLE
Voorzie fallback zonder plyer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,21 @@
 Dit project bevat een eenvoudig Python-script.
 
 ## `wandel_reminder.py`
-Stuurt iedere uur een pushmelding om even een minuut te wandelen.
+Stuurt op vaste intervallen een melding om even te bewegen. Het script
+kan worden aangepast via command line opties en bevat een eenvoudige
+bediening via een klein venster.
+
+### Gebruik
+
+```bash
+python wandel_reminder.py [--interval MINUTEN] [--start HH:MM] [--end HH:MM] [--icon PAD]
+```
+
+- `--interval` bepaalt het aantal minuten tussen meldingen (standaard 60).
+- `--start` en `--end` geven optionele begin- en eindtijden op.
+- `--icon` wijst naar een icoonbestand dat in de melding wordt getoond.
+- Indien de `plyer` bibliotheek ontbreekt wordt een eenvoudige
+  Tkinter-melding getoond.
+
+Elke verstuurde melding wordt gelogd in `wandel_reminder.log`.
 

--- a/wandel_reminder.py
+++ b/wandel_reminder.py
@@ -1,17 +1,120 @@
-from plyer import notification
-import time
+"""Script om een wandelherinnering te sturen."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import logging
+import sys
+
+try:
+    from plyer import notification
+except Exception:  # pragma: no cover - plyer optioneel
+    notification = None
+import tkinter as tk
+from tkinter import messagebox
 
 
-def stuur_melding():
-    notification.notify(
-        title="Tijd voor een korte wandeling",
-        message="Sta even op en wandel 1 minuut voor een betere doorbloeding.",
-        timeout=10
+def _beep() -> None:
+    """Speel een eenvoudige beep af indien mogelijk."""
+    try:
+        import winsound
+
+        winsound.MessageBeep()
+    except Exception:  # pragma: no cover - afhankelijk van OS
+        # Fallback voor andere systemen
+        sys.stdout.write("\a")
+        sys.stdout.flush()
+
+
+def stuur_melding(icon: str | None) -> None:
+    """Stuur de bureaubladmelding en log dit."""
+    kwargs = {
+        "title": "Tijd voor een korte wandeling",
+        "message": "Sta even op en wandel 1 minuut voor een betere doorbloeding.",
+        "timeout": 10,
+    }
+    if icon:
+        kwargs["app_icon"] = icon
+
+    if notification is not None:
+        try:
+            notification.notify(**kwargs)
+        except Exception:
+            messagebox.showinfo(kwargs["title"], kwargs["message"])
+    else:
+        messagebox.showinfo(kwargs["title"], kwargs["message"])
+    _beep()
+    logging.info("Melding verstuurd")
+
+
+def _parse_time(value: str) -> _dt.time:
+    """Zet een HH:MM string om naar ``datetime.time``."""
+    return _dt.datetime.strptime(value, "%H:%M").time()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Wandelherinnering")
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=60,
+        help="Tijd tussen meldingen in minuten (standaard 60).",
     )
+    parser.add_argument("--start", type=_parse_time, help="Starttijd in HH:MM")
+    parser.add_argument("--end", type=_parse_time, help="Eindtijd in HH:MM")
+    parser.add_argument("--icon", help="Pad naar een icoon voor de melding")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        filename="wandel_reminder.log",
+        level=logging.INFO,
+        format="%(asctime)s - %(message)s",
+    )
+
+    interval_ms = args.interval * 60 * 1000
+
+    running = True
+
+    def start() -> None:
+        nonlocal running
+        running = True
+
+    def pause() -> None:
+        nonlocal running
+        running = False
+
+    def stop() -> None:
+        root.destroy()
+
+    def loop() -> None:
+        now = _dt.datetime.now().time()
+        if running:
+            allowed = True
+            if args.start and now < args.start:
+                allowed = False
+            if args.end and now > args.end:
+                allowed = False
+            if allowed:
+                stuur_melding(args.icon)
+        root.after(interval_ms, loop)
+
+    root = tk.Tk()
+    root.title("Wandel Reminder")
+
+    start_btn = tk.Button(root, text="Start", command=start)
+    start_btn.pack(fill="x")
+
+    pause_btn = tk.Button(root, text="Pause", command=pause)
+    pause_btn.pack(fill="x")
+
+    exit_btn = tk.Button(root, text="Exit", command=stop)
+    exit_btn.pack(fill="x")
+
+    root.after(interval_ms, loop)
+    root.mainloop()
 
 
 if __name__ == "__main__":
-    while True:
-        stuur_melding()
-        time.sleep(3600)
+    main()
 


### PR DESCRIPTION
## Summary
- fallback gebruiken wanneer `plyer` ontbreekt
- documentatie over Tkinter-fallback toevoegen

## Testing
- `python -m py_compile wandel_reminder.py`


------
https://chatgpt.com/codex/tasks/task_b_684c024f9fec8333822956b9b542d420