### PR TITLE
Add trigger button to reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Dit project bevat een eenvoudig Python-script.
 ## `wandel_reminder.py`
 Stuurt op vaste intervallen een melding om even te bewegen. Het script
 kan worden aangepast via command line opties en bevat een eenvoudige
-bediening via een klein venster.
+bediening via een klein venster. Het venster toont de knoppen **Start**,
+**Pause**, **Trigger** en **Exit**.
 
 ### Gebruik
 
@@ -16,6 +17,11 @@ python wandel_reminder.py [--interval MINUTEN] [--start HH:MM] [--end HH:MM] [--
 - `--interval` bepaalt het aantal minuten tussen meldingen (standaard 60).
 - `--start` en `--end` geven optionele begin- en eindtijden op.
 - `--icon` wijst naar een icoonbestand dat in de melding wordt getoond.
+
+Het venster kan gewoon geminimaliseerd worden zodat het programma op de
+achtergrond blijft draaien. Op Windows kan het eventueel gestart worden
+met `pythonw` zodat geen consolevenster zichtbaar is. Met de knop
+**Trigger** wordt direct een melding verstuurd om het gedrag te testen.
 
 Elke verstuurde melding wordt gelogd in `wandel_reminder.log`.
 

--- a/wandel_reminder.py
+++ b/wandel_reminder.py
@@ -99,6 +99,11 @@ def main() -> None:
     pause_btn = tk.Button(root, text="Pause", command=pause)
     pause_btn.pack(fill="x")
 
+    trigger_btn = tk.Button(
+        root, text="Trigger", command=lambda: stuur_melding(args.icon)
+    )
+    trigger_btn.pack(fill="x")
+
     exit_btn = tk.Button(root, text="Exit", command=stop)
     exit_btn.pack(fill="x")
 


### PR DESCRIPTION
## Summary
- add a **Trigger** button to send an immediate notification
- document the new button and mention how to keep the app in the background

## Testing
- `python -m py_compile wandel_reminder.py`
- `python wandel_reminder.py --help | head -n 20` *(fails: ModuleNotFoundError: No module named 'plyer')*

------
https://chatgpt.com/codex/tasks/task_b_684c09f8e4fc8333b5dee93e4371fa5d