### PR TITLE
Add settings button to Wandel reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Dit project bevat een eenvoudig Python-script.
 ## `wandel_reminder.py`
 Stuurt op vaste intervallen een melding om even te bewegen. Het script
 kan worden aangepast via command line opties en bevat een eenvoudige
-bediening via een klein venster. Het venster toont de knoppen **Start**,
-**Pause**, **Trigger** en **Exit**.
+bediening via een klein venster. Het venster toont de knoppen **Settings**,
+**Trigger** en **Exit**.
 
 ### Gebruik
 
@@ -17,6 +17,8 @@ python wandel_reminder.py [--interval MINUTEN] [--start HH:MM] [--end HH:MM] [--
 - `--interval` bepaalt het aantal minuten tussen meldingen (standaard 60).
 - `--start` en `--end` geven optionele begin- en eindtijden op.
 - `--icon` wijst naar een icoonbestand dat in de melding wordt getoond.
+
+Met de knop **Settings** kan dit interval tijdens het draaien worden aangepast.
 
 Het venster kan gewoon geminimaliseerd worden zodat het programma op de
 achtergrond blijft draaien. Op Windows kan het eventueel gestart worden

--- a/wandel_reminder.py
+++ b/wandel_reminder.py
@@ -6,10 +6,10 @@ import argparse
 import datetime as _dt
 import logging
 import sys
-import time
 
 from plyer import notification
 import tkinter as tk
+from tkinter import simpledialog
 
 
 def _beep() -> None:
@@ -65,39 +65,37 @@ def main() -> None:
 
     interval_ms = args.interval * 60 * 1000
 
-    running = True
-
-    def start() -> None:
-        nonlocal running
-        running = True
-
-    def pause() -> None:
-        nonlocal running
-        running = False
-
     def stop() -> None:
         root.destroy()
 
+    def open_settings() -> None:
+        nonlocal interval_ms
+        result = simpledialog.askinteger(
+            "Instellingen",
+            "Aantal minuten tussen meldingen:",
+            parent=root,
+            initialvalue=interval_ms // 60000,
+            minvalue=1,
+        )
+        if result is not None:
+            interval_ms = result * 60 * 1000
+
     def loop() -> None:
         now = _dt.datetime.now().time()
-        if running:
-            allowed = True
-            if args.start and now < args.start:
-                allowed = False
-            if args.end and now > args.end:
-                allowed = False
-            if allowed:
-                stuur_melding(args.icon)
+        allowed = True
+        if args.start and now < args.start:
+            allowed = False
+        if args.end and now > args.end:
+            allowed = False
+        if allowed:
+            stuur_melding(args.icon)
         root.after(interval_ms, loop)
 
     root = tk.Tk()
     root.title("Wandel Reminder")
 
-    start_btn = tk.Button(root, text="Start", command=start)
-    start_btn.pack(fill="x")
-
-    pause_btn = tk.Button(root, text="Pause", command=pause)
-    pause_btn.pack(fill="x")
+    settings_btn = tk.Button(root, text="Settings", command=open_settings)
+    settings_btn.pack(fill="x")
 
     trigger_btn = tk.Button(
         root, text="Trigger", command=lambda: stuur_melding(args.icon)


### PR DESCRIPTION
## Summary
- simplify README details for the window buttons
- drop Start/Pause controls in `wandel_reminder.py`
- add Settings button to update the interval on the fly

## Testing
- `python -m py_compile wandel_reminder.py`

------
https://chatgpt.com/codex/tasks/task_b_684c0c3a60448333a1a2067c88960657