### PR TITLE
Add immediate interval rescheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Dit project bevat een eenvoudig Python-script.
 ## `wandel_reminder.py`
 Stuurt op vaste intervallen een melding om even te bewegen. Het script
 kan worden aangepast via command line opties en bevat een eenvoudige
-bediening via een klein venster. Het venster toont de knoppen **Start**,
-**Pause**, **Trigger** en **Exit**.
+bediening via een klein venster. Het venster toont de knoppen **Settings**,
+**Trigger** en **Exit**.
 
 ### Gebruik
 
@@ -17,6 +17,9 @@ python wandel_reminder.py [--interval MINUTEN] [--start HH:MM] [--end HH:MM] [--
 - `--interval` bepaalt het aantal minuten tussen meldingen (standaard 60).
 - `--start` en `--end` geven optionele begin- en eindtijden op.
 - `--icon` wijst naar een icoonbestand dat in de melding wordt getoond.
+
+Met de knop **Settings** kan dit interval tijdens het draaien worden aangepast;
+de wijziging gaat meteen in.
 
 Het venster kan gewoon geminimaliseerd worden zodat het programma op de
 achtergrond blijft draaien. Op Windows kan het eventueel gestart worden


### PR DESCRIPTION
## Summary
- reschedule timer right after changing settings
- document that settings changes apply immediately

## Testing
- `python -m py_compile wandel_reminder.py`


------
https://chatgpt.com/codex/tasks/task_b_684c0c3a60448333a1a2067c88960657